### PR TITLE
Update gumshoe url

### DIFF
--- a/data/prefixes.js
+++ b/data/prefixes.js
@@ -66,7 +66,7 @@ module.exports = [
     "notes": ""
   },
   {
-    "prefixpattern": "2.gum.fm",
+    "prefixpattern": ".gum.fm",
     "prefixname": "Gumshoe",
     "iab": "0",
     "abilities_stats": "0",
@@ -240,5 +240,16 @@ module.exports = [
     "prefixurl": "https://voxalyze.com",
     "prefixprivacyurl": "https://voxalyze.com/legal/privacy-policy/",
     "notes": "https://help.voxalyze.com/article/61-tracking-prefix"
+  },
+  {
+    "prefixpattern": "prfx.byspotify.com",
+    "prefixname": "Spotify",
+    "iab": "0",
+    "abilities_stats": "1",
+    "abilities_tracking": "1",
+    "abilities_dynamicaudio": "0",
+    "prefixurl": "https://ads.spotify.com/en-US/news-and-insights/introducing-spotify-ad-analytics/",
+    "prefixprivacyurl": "https://www.spotify.com/us/legal/ad-analytics-privacy-policy/",
+    "notes": "https://help.adanalytics.spotify.com/install-the-spotify-ad-analytics-podcast-prefix"
   }
 ]

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "opawg-node",
-  "version": "0.1.2",
+  "version": "0.1.5",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "opawg-node",
-      "version": "0.1.2",
+      "version": "0.1.5",
       "license": "MIT",
       "devDependencies": {
         "mocha": "^9.2.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "opawg-node",
-  "version": "0.1.5",
+  "version": "0.1.6",
   "description": "Simple access to OPAWG's useful host and prefix lists",
   "main": "src/index.js",
   "scripts": {


### PR DESCRIPTION
I got gumshoe's url in https://github.com/opawg/podcast-prefixes updated to match `s.gum.fm`
This includes that change and spotify's new prefix from opawg